### PR TITLE
Implement basic try/catch compilation

### DIFF
--- a/lib/src/compiler/debug.dart
+++ b/lib/src/compiler/debug.dart
@@ -44,6 +44,9 @@ extension BufferDebugX on Uint64List {
     Instruction.readProperty: 1,
     Instruction.writeProperty: 1,
     Instruction.call: 1,
+    Instruction.tryStart: 1,
+    Instruction.catchStart: 2,
+    Instruction.endTry: 0,
   };
 
   /// Maps opcodes to their names for debugging and display purposes.
@@ -88,6 +91,9 @@ extension BufferDebugX on Uint64List {
     Instruction.readProperty: 'readProperty',
     Instruction.writeProperty: 'writeProperty',
     Instruction.call: 'call',
+    Instruction.tryStart: 'tryStart',
+    Instruction.catchStart: 'catchStart',
+    Instruction.endTry: 'endTry',
   };
 
   /// Converts a buffer of opcodes into a human-readable string representation.

--- a/lib/src/compiler/instructions.dart
+++ b/lib/src/compiler/instructions.dart
@@ -661,6 +661,22 @@ class Instruction {
   ///   1. Positional arguments as List<dynamic> or null ([Instruction.pushNull]).
   ///   2. Named arguments as Map<String, dynamic> or null ([Instruction.pushNull]).
   static const call = 0x27;
+
+  /// Begins a try block and registers the catch handler target.
+  ///
+  /// **Arguments**
+  ///   1. Target instruction index of the associated catch block.
+  static const tryStart = 0x28;
+
+  /// Marks the start of a catch block and stores the thrown exception.
+  ///
+  /// **Arguments**
+  ///   1. Frame index for the exception variable.
+  ///   2. Variable index within the frame.
+  static const catchStart = 0x29;
+
+  /// Ends exception handling for the current try/catch statement.
+  static const endTry = 0x2A;
 }
 
 /// A function compiled to bytecode.

--- a/lib/src/compiler/naivie_compiler.dart
+++ b/lib/src/compiler/naivie_compiler.dart
@@ -90,8 +90,12 @@ class NaiveCompiler extends Compiler {
 
   @override
   visitCatchBlock(CatchBlockContext ctx) {
-    // TODO: implement visitCatchBlock
-    throw UnimplementedError();
+    frame();
+    final ident = ctx.identifier()!.text;
+    final loc = push(ident);
+    emit(Instruction.catchStart, loc.frame, loc.index);
+    ctx.block()?.accept(this);
+    pop();
   }
 
   @override
@@ -612,8 +616,13 @@ class NaiveCompiler extends Compiler {
 
   @override
   visitTryStmt(TryStmtContext ctx) {
-    // TODO: implement visitTryStmt
-    throw UnimplementedError();
+    final catchJump = prepareJump(Instruction.tryStart);
+    ctx.block()?.accept(this);
+    final endJump = prepareJump(Instruction.jump);
+    finalizeJump(catchJump);
+    ctx.catchBlock()?.accept(this);
+    finalizeJump(endJump);
+    emit(Instruction.endTry);
   }
 
   @override

--- a/test/compiler_test.dart
+++ b/test/compiler_test.dart
@@ -216,4 +216,18 @@ contract Random {
       expect(fn.constants.contains('square'), isTrue);
     });
   });
+
+  group('exceptions', () {
+    test('try/catch compiles', () {
+      final script = baseRandomScript(
+          'try { return foo * 2.0; } catch (e) { return foo * 3.0; }');
+      final result = analyze(InputStream.fromString(script), [randomContract]);
+      expect(result.isSuccess(), isTrue);
+      final compiled = compile(result.getOrThrow());
+      final fn = compiled.implementations['randomNumber']!;
+      expect(fn.buffer.contains(Instruction.tryStart), isTrue);
+      expect(fn.buffer.contains(Instruction.catchStart), isTrue);
+      expect(fn.buffer.contains(Instruction.endTry), isTrue);
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- add opcodes for try/catch handling
- handle try/catch blocks in the naive compiler
- expand debug helpers with the new instructions
- test compilation of try/catch blocks

## Testing
- `dart test`

------
https://chatgpt.com/codex/tasks/task_e_684ac51f5d04832fb12fcecc3f66fc88