### PR TITLE
Implement full VM

### DIFF
--- a/lib/src/compiler/compiler.dart
+++ b/lib/src/compiler/compiler.dart
@@ -112,6 +112,12 @@ abstract class Compiler extends dscriptVisitor<void> {
     }
   }
 
+  /// Number of positional parameters for the function being compiled.
+  int positionalParams = 0;
+
+  /// Mapping of named parameter to its stack index.
+  final Map<String, int> namedParameterIndex = {};
+
   /// Builds the compiled bytecode function.
   BytecodeFunction build() {
     if (_loops.isNotEmpty) {
@@ -121,6 +127,8 @@ abstract class Compiler extends dscriptVisitor<void> {
     return BytecodeFunction(
       buffer,
       constants,
+      positionalParams: positionalParams,
+      namedParameterIndex: Map.unmodifiable(namedParameterIndex),
     );
   }
 

--- a/lib/src/compiler/instructions.dart
+++ b/lib/src/compiler/instructions.dart
@@ -688,9 +688,20 @@ class BytecodeFunction extends Equatable {
   /// Constant pool referenced by [buffer].
   final List<Object?> constants;
 
+  /// Number of positional parameters this function expects.
+  final int positionalParams;
+
+  /// Mapping of named parameter to its index within the first frame.
+  final Map<String, int> namedParameterIndex;
+
   /// Creates a compiled function with [buffer] and [constants].
-  const BytecodeFunction(this.buffer, this.constants);
+  const BytecodeFunction(
+    this.buffer,
+    this.constants, {
+    this.positionalParams = 0,
+    this.namedParameterIndex = const {},
+  });
 
   @override
-  List<Object?> get props => [buffer, constants];
+  List<Object?> get props => [buffer, constants, positionalParams, namedParameterIndex];
 }

--- a/lib/src/compiler/naivie_compiler.dart
+++ b/lib/src/compiler/naivie_compiler.dart
@@ -270,9 +270,26 @@ class NaiveCompiler extends Compiler {
   @override
   visitFunc(FuncContext ctx) {
     frame();
-    ctx.pos?.accept(this);
-    ctx.named?.accept(this);
+
+    final posParams = ctx.pos?.params() ?? [];
+    final namedParams = ctx.named?.params() ?? [];
+
+    positionalParams = posParams.length;
+    namedParameterIndex.clear();
+
+    for (var i = 0; i < posParams.length; i++) {
+      final name = posParams[i].identifier()!.text;
+      push(name);
+    }
+
+    for (var i = 0; i < namedParams.length; i++) {
+      final name = namedParams[i].identifier()!.text;
+      push(name);
+      namedParameterIndex[name] = positionalParams + i;
+    }
+
     ctx.block()?.accept(this);
+
     pop();
   }
 
@@ -287,7 +304,16 @@ class NaiveCompiler extends Compiler {
   visitHook(HookContext ctx) {
     frame();
 
-    ctx.params()?.accept(this);
+    final params = ctx.params()?.params() ?? [];
+
+    positionalParams = 0;
+    namedParameterIndex.clear();
+
+    for (var i = 0; i < params.length; i++) {
+      final name = params[i].identifier()!.text;
+      push(name);
+      namedParameterIndex[name] = i;
+    }
 
     ctx.block()?.accept(this);
 
@@ -329,7 +355,17 @@ class NaiveCompiler extends Compiler {
   @override
   visitImpl(ImplContext ctx) {
     frame();
-    ctx.params()?.accept(this);
+
+    final params = ctx.params()?.params() ?? [];
+
+    positionalParams = 0;
+    namedParameterIndex.clear();
+
+    for (var i = 0; i < params.length; i++) {
+      final name = params[i].identifier()!.text;
+      push(name);
+      namedParameterIndex[name] = i;
+    }
 
     ctx.block()?.accept(this);
 

--- a/lib/src/runtime/runtime.dart
+++ b/lib/src/runtime/runtime.dart
@@ -1,6 +1,7 @@
 import 'dart:isolate';
 
 import 'package:dscript/dscript.dart';
+import 'package:dscript/src/stdlib/stdlib.dart';
 
 /// The Dscript runtime environment.
 ///
@@ -24,6 +25,8 @@ class Runtime {
     BytecodeFunction, {
     List<dynamic> args,
     Map<String, dynamic> namedArgs,
+    Map<String, BytecodeFunction> functions,
+    Map<String, LibraryBinding> libraries,
   }) vmFactory;
 
   /// A list of permissions that are missing for the script to run.
@@ -71,7 +74,23 @@ class Runtime {
 
     final impl = script.implementations[implementation]!;
 
-    final vm = vmFactory(impl, args: [], namedArgs: namedArgs);
+    final functions = {
+      ...script.functions,
+      ...script.implementations,
+      ...script.hooks,
+    };
+    final libraries = {
+      for (final lib in LibraryBinding.stdLib()) lib.name: lib,
+      script.contract.bindings.name: script.contract.bindings,
+    };
+
+    final vm = vmFactory(
+      impl,
+      args: [],
+      namedArgs: namedArgs,
+      functions: functions,
+      libraries: libraries,
+    );
 
     return Isolate.run(vm.exec);
   }
@@ -102,7 +121,23 @@ class Runtime {
 
     final hookImpl = script.hooks[hook]!;
 
-    final vm = vmFactory(hookImpl, args: [], namedArgs: namedArgs);
+    final functions = {
+      ...script.functions,
+      ...script.implementations,
+      ...script.hooks,
+    };
+    final libraries = {
+      for (final lib in LibraryBinding.stdLib()) lib.name: lib,
+      script.contract.bindings.name: script.contract.bindings,
+    };
+
+    final vm = vmFactory(
+      hookImpl,
+      args: [],
+      namedArgs: namedArgs,
+      functions: functions,
+      libraries: libraries,
+    );
 
     await Isolate.run(vm.exec);
   }

--- a/lib/src/vm/vm.dart
+++ b/lib/src/vm/vm.dart
@@ -1,4 +1,6 @@
 import 'package:dscript/dscript.dart';
+import 'package:dscript/src/runtime/exceptions.dart';
+import 'package:dscript/src/stdlib/stdlib.dart';
 
 part 'vm_impl.dart';
 
@@ -14,11 +16,24 @@ abstract class VM {
   final Map<String, dynamic> namedArgs;
 
   /// A virtual machine executing a [BytecodeFunction].
+  ///
+  /// The [functions] map contains all bytecode functions available for
+  /// invocation via the [Instruction.call] opcode. The [libraries] map provides
+  /// access to host or standard library bindings used by
+  /// [Instruction.externalCall].
   VM(
     this.function, {
     this.args = const [],
     this.namedArgs = const {},
+    this.functions = const {},
+    this.libraries = const {},
   });
+
+  /// All functions that can be invoked by this VM.
+  final Map<String, BytecodeFunction> functions;
+
+  /// Available libraries for external calls keyed by namespace.
+  final Map<String, LibraryBinding> libraries;
 
   /// Executes the function with the provided [args] and [namedArgs].
   ///

--- a/lib/src/vm/vm_impl.dart
+++ b/lib/src/vm/vm_impl.dart
@@ -7,11 +7,316 @@ class DefaultVM extends VM {
     super.function, {
     super.args,
     super.namedArgs,
+    super.functions,
+    super.libraries,
   });
 
   @override
-  exec() {
-    // TODO: implement exec
-    throw UnimplementedError();
+  dynamic exec() {
+    final buffer = function.buffer;
+    final constants = function.constants;
+
+    final stack = <dynamic>[];
+    final Map<int, Map<int, dynamic>> frames = {};
+    final List<int> catchTargets = [];
+
+    void _store(int frame, int index, dynamic value) {
+      frames.putIfAbsent(frame, () => {})[index] = value;
+    }
+
+    dynamic _read(int frame, int index) {
+      return frames[frame]?[index];
+    }
+
+    // Initialize first frame with positional and named arguments.
+    if (args.isNotEmpty || namedArgs.isNotEmpty) {
+      var frame = frames.putIfAbsent(1, () => {});
+      for (var i = 0; i < args.length; i++) {
+        frame[i] = args[i];
+      }
+      for (final entry in namedArgs.entries) {
+        final idx = function.namedParameterIndex[entry.key];
+        if (idx != null) {
+          frame[idx] = entry.value;
+        }
+      }
+    }
+
+    dynamic result;
+    for (var ip = 0; ip < buffer.length;) {
+      final opcode = buffer[ip++];
+      switch (opcode) {
+        case Instruction.store:
+          final frame = buffer[ip++];
+          final index = buffer[ip++];
+          _store(frame, index, stack.removeLast());
+          break;
+        case Instruction.read:
+          final frame = buffer[ip++];
+          final index = buffer[ip++];
+          stack.add(_read(frame, index));
+          break;
+        case Instruction.add:
+          final b = stack.removeLast() as num;
+          final a = stack.removeLast() as num;
+          stack.add(a + b);
+          break;
+        case Instruction.sub:
+          final b = stack.removeLast() as num;
+          final a = stack.removeLast() as num;
+          stack.add(a - b);
+          break;
+        case Instruction.mul:
+          final b = stack.removeLast() as num;
+          final a = stack.removeLast() as num;
+          stack.add(a * b);
+          break;
+        case Instruction.div:
+          final b = stack.removeLast() as num;
+          final a = stack.removeLast() as num;
+          stack.add(a / b);
+          break;
+        case Instruction.mod:
+          final b = stack.removeLast() as num;
+          final a = stack.removeLast() as num;
+          stack.add(a % b);
+          break;
+        case Instruction.eq:
+          final b = stack.removeLast();
+          final a = stack.removeLast();
+          stack.add(a == b);
+          break;
+        case Instruction.neq:
+          final b = stack.removeLast();
+          final a = stack.removeLast();
+          stack.add(a != b);
+          break;
+        case Instruction.lt:
+          final b = stack.removeLast() as num;
+          final a = stack.removeLast() as num;
+          stack.add(a < b);
+          break;
+        case Instruction.gt:
+          final b = stack.removeLast() as num;
+          final a = stack.removeLast() as num;
+          stack.add(a > b);
+          break;
+        case Instruction.lte:
+          final b = stack.removeLast() as num;
+          final a = stack.removeLast() as num;
+          stack.add(a <= b);
+          break;
+        case Instruction.gte:
+          final b = stack.removeLast() as num;
+          final a = stack.removeLast() as num;
+          stack.add(a >= b);
+          break;
+        case Instruction.and:
+          final b = stack.removeLast() as bool;
+          final a = stack.removeLast() as bool;
+          stack.add(a && b);
+          break;
+        case Instruction.or:
+          final b = stack.removeLast() as bool;
+          final a = stack.removeLast() as bool;
+          stack.add(a || b);
+          break;
+        case Instruction.not:
+          final a = stack.removeLast() as bool;
+          stack.add(!a);
+          break;
+        case Instruction.jump:
+          final target = buffer[ip++];
+          ip = target;
+          break;
+        case Instruction.jumpIfTrue:
+          final target = buffer[ip++];
+          final condition = stack.removeLast();
+          if (condition == true) ip = target;
+          break;
+        case Instruction.jumpIfFalse:
+          final target = buffer[ip++];
+          final condition = stack.removeLast();
+          if (condition == false) ip = target;
+          break;
+        case Instruction.ret:
+          result = stack.isNotEmpty ? stack.removeLast() : null;
+          return result;
+        case Instruction.pushConstant:
+          final idx = buffer[ip++];
+          stack.add(constants[idx]);
+          break;
+        case Instruction.pushNull:
+          stack.add(null);
+          break;
+        case Instruction.neg:
+          final a = stack.removeLast() as num;
+          stack.add(-a);
+          break;
+        case Instruction.array:
+          final count = buffer[ip++];
+          final items = List<dynamic>.generate(
+            count,
+            (_) => stack.removeLast(),
+          ).reversed.toList();
+          stack.add(items);
+          break;
+        case Instruction.map:
+          final count = buffer[ip++];
+          final m = <String, dynamic>{};
+          for (var i = 0; i < count; i++) {
+            final value = stack.removeLast();
+            final key = stack.removeLast() as String;
+            m[key] = value;
+          }
+          stack.add(m);
+          break;
+        case Instruction.readProperty:
+          final idx = buffer[ip++];
+          final obj = stack.removeLast();
+          final prop = constants[idx];
+          if (obj is Map) {
+            stack.add(obj[prop]);
+          } else {
+            stack.add((obj as dynamic)[prop]);
+          }
+          break;
+        case Instruction.writeProperty:
+          final idx = buffer[ip++];
+          final obj = stack.removeLast();
+          final value = stack.removeLast();
+          final prop = constants[idx];
+          if (obj is Map) {
+            obj[prop] = value;
+          } else {
+            (obj as dynamic)[prop] = value;
+          }
+          break;
+        case Instruction.readElement:
+          final index = stack.removeLast();
+          final obj = stack.removeLast();
+          if (obj is List) {
+            stack.add(obj[index as int]);
+          } else if (obj is Map) {
+            stack.add(obj[index]);
+          } else {
+            stack.add((obj as dynamic)[index]);
+          }
+          break;
+        case Instruction.writeElement:
+          final value = stack.removeLast();
+          final index = stack.removeLast();
+          final obj = stack.removeLast();
+          if (obj is List) {
+            obj[index as int] = value;
+          } else if (obj is Map) {
+            obj[index] = value;
+          } else {
+            (obj as dynamic)[index] = value;
+          }
+          break;
+        case Instruction.call:
+          final idx = buffer[ip++];
+          final named = stack.removeLast() as Map<String, dynamic>?;
+          final positional = stack.removeLast() as List<dynamic>?;
+          final name = constants[idx] as String;
+          final fn = functions[name];
+          if (fn == null) {
+            throw StateError('Function $name not found');
+          }
+          final vm = DefaultVM(
+            fn,
+            args: positional ?? const [],
+            namedArgs: named ?? const {},
+            functions: functions,
+            libraries: libraries,
+          );
+          stack.add(vm.exec());
+          break;
+        case Instruction.externalCall:
+          final nsIdx = buffer[ip++];
+          final fnIdx = buffer[ip++];
+          final named = stack.removeLast() as Map<String, dynamic>?;
+          final positional = stack.removeLast() as List<dynamic>?;
+          final namespace = constants[nsIdx] as String;
+          final name = constants[fnIdx] as String;
+          final lib = libraries[namespace];
+          if (lib == null) {
+            throw StateError('Unknown namespace $namespace');
+          }
+          final binding = lib.bindings
+              .firstWhere((b) => b.name == name, orElse: () => throw StateError('Unknown function $name in $namespace'));
+          final result = Function.apply(
+            binding.function,
+            positional ?? const [],
+            named?.map((k, v) => MapEntry(Symbol(k), v)),
+          );
+          stack.add(result);
+          break;
+        case Instruction.structFromMap:
+          final idx = buffer[ip++];
+          final map = Map<String, dynamic>.from(stack.removeLast() as Map);
+          map['__type'] = constants[idx];
+          stack.add(map);
+          break;
+        case Instruction.shl:
+          final b = stack.removeLast() as int;
+          final a = stack.removeLast() as int;
+          stack.add(a << b);
+          break;
+        case Instruction.shr:
+          final b = stack.removeLast() as int;
+          final a = stack.removeLast() as int;
+          stack.add(a >> b);
+          break;
+        case Instruction.bitwiseAnd:
+          final b = stack.removeLast() as int;
+          final a = stack.removeLast() as int;
+          stack.add(a & b);
+          break;
+        case Instruction.bitwiseOr:
+          final b = stack.removeLast() as int;
+          final a = stack.removeLast() as int;
+          stack.add(a | b);
+          break;
+        case Instruction.bitwiseXor:
+          final b = stack.removeLast() as int;
+          final a = stack.removeLast() as int;
+          stack.add(a ^ b);
+          break;
+        case Instruction.inc:
+          final a = stack.removeLast() as num;
+          stack.add(a + 1);
+          break;
+        case Instruction.dec:
+          final a = stack.removeLast() as num;
+          stack.add(a - 1);
+          break;
+        case Instruction.throw_:
+          final error = stack.removeLast();
+          if (catchTargets.isEmpty) {
+            throw RuntimeException(error.toString());
+          }
+          stack.add(error);
+          ip = catchTargets.last;
+          break;
+        case Instruction.tryStart:
+          final target = buffer[ip++];
+          catchTargets.add(target);
+          break;
+        case Instruction.catchStart:
+          final frame = buffer[ip++];
+          final index = buffer[ip++];
+          _store(frame, index, stack.removeLast());
+          break;
+        case Instruction.endTry:
+          if (catchTargets.isNotEmpty) catchTargets.removeLast();
+          break;
+        default:
+          throw UnimplementedError('Opcode $opcode not implemented');
+      }
+    }
+
+    return result;
   }
 }

--- a/test/vm_test.dart
+++ b/test/vm_test.dart
@@ -1,0 +1,102 @@
+import 'package:test/test.dart';
+import 'package:antlr4/antlr4.dart';
+import 'package:dscript/dscript.dart';
+
+import 'shared.dart';
+
+void main() {
+  test('vm executes simple function', () async {
+    final script = baseRandomScript('return foo * 2.0;');
+    final result = analyze(InputStream.fromString(script), [randomContract]);
+    expect(result.isSuccess(), isTrue);
+
+    final compiled = compile(result.getOrThrow());
+    final runtime = Runtime(compiled, []);
+
+    final value = await runtime.run('randomNumber', namedArgs: {'foo': 21});
+    expect(value, 42.0);
+  });
+
+  test('vm executes internal function call', () async {
+    final script = '''
+author "A";
+version 1.0.0;
+name "S";
+description "D";
+contract Random {
+  func square(int x) -> int { return x * x; }
+  impl randomNumber(int foo) -> double {
+    final int y = square(foo);
+    return y * 1.0;
+  }
+  impl randomString() -> string { return ""; }
+  impl test() -> void { return; }
+  hook onLogin(string username) { return; }
+  hook onLogout() { return; }
+}
+''';
+
+    final result = analyze(InputStream.fromString(script), [randomContract]);
+    expect(result.isSuccess(), isTrue);
+
+    final compiled = compile(result.getOrThrow());
+    final runtime = Runtime(compiled, []);
+
+    final value = await runtime.run('randomNumber', namedArgs: {'foo': 21});
+    expect(value, 441.0);
+  });
+
+  test('vm executes external call', () async {
+    final script = baseRandomScript('return math::floor(foo * 2.5) * 1.0;');
+    final result = analyze(InputStream.fromString(script), [randomContract]);
+    expect(result.isSuccess(), isTrue);
+
+    final compiled = compile(result.getOrThrow());
+    final runtime = Runtime(compiled, []);
+
+    final value = await runtime.run('randomNumber', namedArgs: {'foo': 21});
+    expect(value, 52.0);
+  });
+
+  test('named arguments work regardless of order', () async {
+    final script = '''
+author "A";
+version 1.0.0;
+name "S";
+description "D";
+contract Pair {
+  impl diff(int a, int b) -> int {
+    return a - b;
+  }
+}
+''';
+
+    final contract = ContractSignature(
+      name: 'Pair',
+      implementations: [
+        ImplementationSignature(
+          name: 'diff',
+          namedParameters: [
+            const ParameterSignature(name: 'a', type: PrimitiveType.INT),
+            const ParameterSignature(name: 'b', type: PrimitiveType.INT),
+          ],
+          returnType: PrimitiveType.INT,
+        ),
+      ],
+      hooks: const [],
+      bindings: ExternalBindings(),
+    );
+
+    final result = analyze(InputStream.fromString(script), [contract]);
+    expect(result.isSuccess(), isTrue);
+
+    final compiled = compile(result.getOrThrow());
+    final runtime = Runtime(compiled, []);
+
+    final value = await runtime.run(
+      'diff',
+      namedArgs: {'b': 2, 'a': 5},
+    );
+    expect(value, 3);
+  });
+}


### PR DESCRIPTION
## Summary
- extend bytecode metadata with parameter info
- fix VM initialization of named args to respect parameter order
- store parameter information when compiling functions
- add regression test for named argument order

## Testing
- `dart analyze` *(fails: missing Dart SDK)*
- `dart test` *(fails: missing Dart SDK)*

------
https://chatgpt.com/codex/tasks/task_e_684af1b64c98832f9df8d057f959804c