### PR TITLE
fix(analyzer): improve constant handling

### DIFF
--- a/lib/src/analyzer/visitors/flow.dart
+++ b/lib/src/analyzer/visitors/flow.dart
@@ -30,20 +30,20 @@ class FlowVisitor extends AnalysisVisitor {
       ));
     }
 
-    // TODO: Handle constant expressions for true/false conditions
-    // This is a simple check, but it can be improved with constant folding.
-    if (ctx.text == 'true') {
-      report(SemanticWarning(
-          'Condition is always true, this branch will always execute.',
-          ctx: ctx));
-    }
-
-    // TODO: Handle constant expressions for true/false conditions
-    // This is a simple check, but it can be improved with constant folding.
-    if (ctx.text == 'false') {
-      report(SemanticWarning(
-          'Condition is always false, this branch will never execute.',
-          ctx: ctx));
+    if (isConstExpr(ctx)) {
+      if (ctx.text == 'true') {
+        report(SemanticWarning(
+            'Condition is always true, this branch will always execute.',
+            ctx: ctx));
+      } else if (ctx.text == 'false') {
+        report(SemanticWarning(
+            'Condition is always false, this branch will never execute.',
+            ctx: ctx));
+      } else {
+        report(SemanticWarning(
+            'Condition is constant, this branch will always have the same outcome.',
+            ctx: ctx));
+      }
     }
 
     return condition;

--- a/lib/src/analyzer/visitors/vars.dart
+++ b/lib/src/analyzer/visitors/vars.dart
@@ -147,8 +147,8 @@ class VarsVisitor extends AnalysisVisitor {
     final name = ctx.identifier()?.text ??
         ctx.assignment()?.simpleAssignment()?.identifier()?.text;
 
-    final initializer =
-        ctx.assignment()?.simpleAssignment()?.expr()?.accept(ExprVisitor(this));
+    final initCtx = ctx.assignment()?.simpleAssignment()?.expr();
+    final initializer = initCtx?.accept(ExprVisitor(this));
 
     final isMutable = varType.VAR() != null;
 
@@ -177,6 +177,17 @@ class VarsVisitor extends AnalysisVisitor {
                 "Immutable non-nullable variable '$name' must have an initializer",
                 ctx: ctx,
               ),
+      );
+    }
+
+    final isConst = ctx.varType()?.CONST() != null;
+
+    if (isConst && initCtx != null && !isConstExpr(initCtx)) {
+      report(
+        SemanticError(
+          'Constant variable "$name" must be initialized with only literals or other constants',
+          ctx: ctx,
+        ),
       );
     }
 


### PR DESCRIPTION
## Summary
- detect constant expressions in analyzer
- enforce constant initializer rules for const variables
- warn on constant conditions in flow control
- test constant expression analysis

## Testing
- `dart format lib/src/analyzer/visitors/visitors.dart lib/src/analyzer/visitors/vars.dart lib/src/analyzer/visitors/flow.dart test/analyzer_test.dart`
- `dart test`

------
https://chatgpt.com/codex/tasks/task_e_684ceff124d8832fb143d64638e5c981